### PR TITLE
Event Display

### DIFF
--- a/TEveEventDisplay/fcl/display_all.fcl
+++ b/TEveEventDisplay/fcl/display_all.fcl
@@ -1,4 +1,12 @@
 
+# roneil: added some standard includes to get display running
+#include "TrkHitReco/fcl/prolog.fcl"
+#include "fcl/minimalMessageService.fcl"
+#include "fcl/standardProducers.fcl"
+#include "fcl/standardServices.fcl"
+
+
+
 #include "TEveEventDisplay/fcl/prolog.fcl"
 
 process_name : Display


### PR DESCRIPTION
Hi Sophie,

While the tracking stuff is being organised, I was poking around and saw you'd made quite a bit of headway into creating the Event Display already and getting the TEve stuff to compile (I had major problems until I realised the TGL and Eve stuff are compiled into external libraries).

As you suggested a while ago, It'd be great to collaborate to get it working if possible (?).

Before I get into it, I've tried compiling it (it compiled fine) and running mu2e -c TEveEventDisplay/fcl/display_all.fcl to start with, but got hit with some fcl include errors. I added it at the end. Did you manage to get TEve to run/display a window yet?

Best wishes, Ryun

cet::exception caught in art
---- OtherArt BEGIN
ServiceCreation
---- ServiceNotFound BEGIN
Unable to create ServiceHandle.
Perhaps the FHiCL configuration does not specify the necessary service?
The class of the service is noted below...
---- OtherArt BEGIN
ServiceCreation
---- Can't find key BEGIN
simulatedDetector.tool_type
---- Can't find key END
cet::exception caught during construction of service type mu2e::GeometryService:
---- OtherArt END
---- ServiceNotFound END
cet::exception caught during construction of service type mu2e::ConditionsService:
---- OtherArt END
%MSG
Art has completed and will exit with status 1.

